### PR TITLE
Add option to allow setting the cluster scheduling policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ can take several options in addition to the file path:
 * `callback` - A callback to call when forky has launched the workers
 * `enable_logging` - Whether to enable forky logging (default: `false`)
 * `kill_timeout` - The kill timeout (milliseconds) to use if a worker does not kill shutdown properly and is not given a timeout when it is told to disconnect (default: `1000`)
+* `scheduling_policy`` - The scheduling policy to use for cluster.
 
 ## Contributing
 

--- a/index.js
+++ b/index.js
@@ -63,6 +63,9 @@ var forky = (module.exports = function(options, workerCount, cb) {
     if (options.kill_timeout !== undefined) {
       KILL_TIMEOUT = options.kill_timeout
     }
+    if (options.scheduling_policy !== undefined) {
+      cluster.schedulingPolicy = options.scheduling_policy;
+    }
   }
 
   if (undefined === workerCount) {


### PR DESCRIPTION
This PR adds a passthrough option to set the `cluster.schedulingPolicy`.

According the the [cluster.schedulingPolicy](https://nodejs.org/docs/latest-v8.x/api/cluster.html#cluster_cluster_schedulingpolicy) documentation:

> SCHED_RR is the default on all operating systems except Windows. Windows will change to SCHED_RR once libuv is able to effectively distribute IOCP handles without incurring a large performance hit.

A did a limited amount of testing and turns out that Windows is never turning to round robin.

I did use the `NODE_CLUSTER_SCHED_POLICY` environment variable which allowed round robin scheduling, but this would probably not be the recommend approach for most servers.