### PR TITLE
Add .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,5 @@
+examples
+Makefile
+node_modules
+test
+.travis.yml


### PR DESCRIPTION
Adds an .npmignore that skips the build related files, tests, and examples. Shrinks the overall package size down a bit.